### PR TITLE
Fix incorrect deletion of the end "param" tag.

### DIFF
--- a/src/Fue/Extensions.fs
+++ b/src/Fue/Extensions.fs
@@ -15,5 +15,6 @@ type HtmlDocument with
         let doc = HtmlDocument.Create()
         // fix for http://stackoverflow.com/questions/293342/htmlagilitypack-drops-option-end-tags
         HtmlNode.ElementsFlags.Remove("option") |> ignore
+        HtmlNode.ElementsFlags.Remove("param") |> ignore
         doc.LoadHtml(html)
         doc.DocumentNode


### PR DESCRIPTION
Configure HtmlAgilityPack not to delete the end </param> tag.

Closes #8.