### PR TITLE
Add $last and $not-last variables in loop.

### DIFF
--- a/src/Fue/NodeCompiler.fs
+++ b/src/Fue/NodeCompiler.fs
@@ -98,15 +98,17 @@ let private compileForCycle compileFun (source:HtmlNode) data itemName cycle =
     >>= checkIsIterable
     >>= (fun list ->
         let length = Seq.length list
-        list |> Seq.map (fun itemValue ->
-            let index = (list |> Seq.findIndex (fun x -> x = itemValue))
-            let dataWithItem = 
-                data 
-                //|> add itemName itemValue 
+        list |> Seq.mapi (fun index itemValue ->
+            let iteration = index + 1
+            let dataWithItem =
+                data
+                //|> add itemName itemValue
                 |> addForCycleItem itemName itemValue
                 |> add "$index" index
-                |> add "$iteration" (index + 1)
+                |> add "$iteration" iteration
                 |> add "$length" length
+                |> add "$last" (length = iteration)
+                |> add "$not-last" (length <> iteration)
             compileNode compileFun source dataWithItem filterFor
         ) |> Seq.toList |> Rop.fold
     )

--- a/tests/Fue.Tests/Compiler.fs
+++ b/tests/Fue.Tests/Compiler.fs
@@ -132,6 +132,12 @@ let ``Compiles additional info for forcycle`` () =
     |> should equal """<test><li>A is 0, 1, 3</li><li>B is 1, 2, 3</li><li>C is 2, 3, 3</li></test>"""
 
 [<Test>]
+let ``Compiles $last and $not-last`` () =
+    init |> add "items" ["A";"B";"C"]
+    |> fromText """<test><li fs-for="i in items">{{{i}}}<fs-template fs-if="$not-last">,</fs-template><fs-template fs-if="$last">!</fs-template></li></test>"""
+    |> should equal """<test><li>A,</li><li>B,</li><li>C!</li></test>"""
+
+[<Test>]
 let ``Compiles with complex html`` () = 
     init 
     |> add "menu" """<!-- MENU --><div class="menu"><a href="javascript:;">Test</a></div>"""


### PR DESCRIPTION
Also, fix quadratic complexity caused by `list |> Seq.findIndex`
inside `map` when compiling `fs-for`, now it should be linear.

Closes #7.