### PR TITLE
Compiles without generating closing tags when parsing none html templ…

### DIFF
--- a/src/Fue/Fue.xml
+++ b/src/Fue/Fue.xml
@@ -22,6 +22,16 @@
  Applies attributes/interpolation logic onto Html node tree
 </summary>
 </member>
+<member name="M:Fue.Compiler.fromNoneHtmlFile(System.String)">
+<summary>
+ Compiles none html file content
+</summary>
+</member>
+<member name="M:Fue.Compiler.fromNoneHtmlText(System.String,Microsoft.FSharp.Collections.FSharpMap{System.String,System.Object})">
+<summary>
+ Compiles none html text
+</summary>
+</member>
 <member name="M:Fue.Compiler.fromFileSafe(System.String)">
 <summary>
  Compiles file content with escaping dangerous chars

--- a/tests/Fue.Tests/Issues.fs
+++ b/tests/Fue.Tests/Issues.fs
@@ -42,3 +42,13 @@ let ``Parses correctly with spaces (Issue #4)``() =
                 TemplateValue.Literal("MMMM yyyy")
                 TemplateValue.Function("now", [])
             ]))
+    
+[<Test>]
+let ``Parse angel brackets correctly and do not add closing endtag (Issue #16)``() =
+    let template = """<fs-template fs-if="render">ArrayList<Class<{{{change(obj)}}}>></fs-template>"""
+    init
+    |> add "obj" "Entity"
+    |> add "change" (fun (x: string) -> x.ToUpper())
+    |> add "render" true
+    |> fromNoneHtmlText template
+    |> should equal "ArrayList<Class<ENTITY>>"


### PR DESCRIPTION
Now you can parse none html template. I am sure there is a more elegant solution to my problem, but it works. 

- you can add as many "unclosed" tags as you want and it don't bother with the fs-attributes and fs-template tag
- compiles the fs-attributes when directly to an "unclosed" tag
- did this as a new from... function, so nothing get's in the way of the previous behaviour

Looking forward to hear your opinion.

Cheers