### PR TITLE
Add support for default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ let compiledHtml = init |> add "name" "Roman" |> fromText html
 // compiledHtml now contains "<div>Roman</div>"
 ```
 
+If a variable is not defined, it gets rendered as is - including the braces.
+
+```fsharp
+let html = "<div>{{{name}}}</div>"
+let compiledHtml = init |> fromText html
+// compiledHtml now contains "<div>{{{name}}}</div>"
+```
+
+However, if you want to have a default value in case the variable is not defined, you can do that with `??`:
+```fsharp
+let html = "<div>{{{name ?? "Roman"}}}</div>"
+let compiledHtml = init |> fromText html
+// compiledHtml now contains "<div>Roman</div>"
+```
+
 Wanna use functions? No problem!
 
 ```fsharp
@@ -307,6 +322,7 @@ literal"""}}}
 
 <!--Template basics-->
 {{{value}}} - Static value
+{{{value ?? "default value"}}} - Default Value
 {{{function()}}} - Function value
 {{{value1 |> fun1}}}
 {{{ { key = value; key2 = value2 } }}}

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ let compiledHtml = init |> fromText html
 // compiledHtml now contains "<div>{{{name}}}</div>"
 ```
 
-However, if you want to have a default value in case the variable is not defined, you can do that with `??`:
+However, if you want to have a default value in case the variable is not defined or `null`, you can do that with `??`:
 ```fsharp
 let html = "<div>{{{name ?? "Roman"}}}</div>"
 let compiledHtml = init |> fromText html

--- a/src/Fue/Core.fs
+++ b/src/Fue/Core.fs
@@ -5,6 +5,7 @@ type TemplateValue =
     | Function of name:string * parameters:TemplateValue list
     | Literal of value:obj
     | Record of Map<string, TemplateValue>
+    | NullCoalesce of TemplateValue * TemplateValue
 
 type TemplateNode =
     | ForCycle of item:string * source:TemplateValue

--- a/src/Fue/ValueCompiler.fs
+++ b/src/Fue/ValueCompiler.fs
@@ -83,8 +83,9 @@ let compile data value =
             | Literal(value) -> value |> success
             | NullCoalesce (left, right) ->
                 match comp left with
-                | Failure _ -> comp right
-                | Success result -> Success result
+                | Failure _
+                | Success null -> comp right
+                | result -> result
 
             | Record(record) ->
                 let compiledRecord =

--- a/src/Fue/ValueCompiler.fs
+++ b/src/Fue/ValueCompiler.fs
@@ -81,6 +81,11 @@ let compile data value =
                     | Method(ob, mi) -> mi.Invoke(ob, methodParams)
                 )
             | Literal(value) -> value |> success
+            | NullCoalesce (left, right) ->
+                match comp left with
+                | Failure _ -> comp right
+                | Success result -> Success result
+
             | Record(record) ->
                 let compiledRecord =
                     record

--- a/tests/Fue.Tests/Compiler.fs
+++ b/tests/Fue.Tests/Compiler.fs
@@ -52,14 +52,6 @@ module NullCoalesce =
         |> should equal "Non-Default Value"
 
     [<Test>]
-    let ``Default value gets used even if it is null``() =
-        let html = """{{{ fn() ?? "Default Value" }}}"""
-        init 
-        |> add "fn" (fun () -> null)
-        |> fromText html
-        |> should equal ""
-
-    [<Test>]
     let ``Default value as function parameter gets evaluated (left side)``() =
         let html = """{{{ fn(var ?? "Default Value") }}}"""
         init 
@@ -73,6 +65,22 @@ module NullCoalesce =
         let html = """{{{ fn(var ?? "Default Value") }}}"""
         init 
         |> add "fn" (fun var -> var)
+        |> fromText html
+        |> should equal "Default Value"
+
+    [<Test>]
+    let ``Evaluated null value on the left side causes right side to evaluate``() =
+        let html = """{{{ nonDefaultFunction() ?? "Default Value" }}}"""
+        init 
+        |> add "nonDefaultFunction" (fun () -> null)
+        |> fromText html
+        |> should equal "Default Value"
+
+    [<Test>]
+    let ``Null value on the left side causes right side to evaluate``() =
+        let html = """{{{myValue ?? "Default Value"}}}"""
+        init 
+        |> add "myValue" null
         |> fromText html
         |> should equal "Default Value"
 

--- a/tests/Fue.Tests/Compiler.fs
+++ b/tests/Fue.Tests/Compiler.fs
@@ -484,6 +484,14 @@ let ``Does not use default value if left side is evaluated function``() =
     |> should equal "Non-Default Value"
 
 [<Test>]
+let ``Defautl value gets used even if it is null``() =
+    let html = """{{{ fn() ?? "Default Value" }}}"""
+    init 
+    |> add "fn" (fun () -> null)
+    |> fromText html
+    |> should equal ""
+
+[<Test>]
 let ``Supports fromTextSafe function``() =
     let html = """{{{myValue}}}"""
     init 

--- a/tests/Fue.Tests/Compiler.fs
+++ b/tests/Fue.Tests/Compiler.fs
@@ -84,6 +84,14 @@ module NullCoalesce =
         |> fromText html
         |> should equal "Default Value"
 
+    [<Test>]
+    let ``Null coalescing operator can be chained``() =
+        let html = """{{{myValue ?? notDefined ?? "Default Value"}}}"""
+        init 
+        |> add "myValue" null
+        |> fromText html
+        |> should equal "Default Value"
+
 [<Test>]
 let ``Compiles the same value twice`` () = 
     let html = "{{{  value   }}}|{{{value}}}"

--- a/tests/Fue.Tests/Compiler.fs
+++ b/tests/Fue.Tests/Compiler.fs
@@ -446,12 +446,51 @@ let ``Supports functions for options without value``() =
     |> should equal "NOPE"
 
 [<Test>]
+let ``Supports default values``() =
+    let html = """{{{myValue ?? "Default Value"}}}"""
+    init 
+    |> fromText html
+    |> should equal "Default Value"
+
+[<Test>]
+let ``Supports functions as default values``() =
+    let html = """{{{myValue ?? defaultFunction()}}}"""
+    init 
+    |> add "defaultFunction" (fun () -> "Default Value")
+    |> fromText html
+    |> should equal "Default Value"
+
+[<Test>]
+let ``Does not use default value if left side is defined``() =
+    let html = """{{{myValue ?? "Default Value"}}}"""
+    init 
+    |> add "myValue" "non-default"
+    |> fromText html
+    |> should equal "non-default"
+
+[<Test>]
+let ``Does not use default value if left side is literal``() =
+    let html = """{{{"non-default" ?? "Default Value"}}}"""
+    init 
+    |> fromText html
+    |> should equal "non-default"
+
+[<Test>]
+let ``Does not use default value if left side is evaluated function``() =
+    let html = """{{{ nonDefaultFunction() ?? "Default Value" }}}"""
+    init 
+    |> add "nonDefaultFunction" (fun () -> "Non-Default Value")
+    |> fromText html
+    |> should equal "Non-Default Value"
+
+[<Test>]
 let ``Supports fromTextSafe function``() =
     let html = """{{{myValue}}}"""
     init 
     |> add "myValue" "<i>Hello</i>"
     |> fromTextSafe html
     |> should equal "&lt;i&gt;Hello&lt;/i&gt;"
+
 
 
 [<Test>]

--- a/tests/Fue.Tests/Parser.fs
+++ b/tests/Fue.Tests/Parser.fs
@@ -42,6 +42,49 @@ let multiLineRecordWithPipedFunctionAndParameterVariable = "{
 }"
 
 
+module NullCoalesce =
+    [<Test>]
+    let ``Parses null coalesce operator with string literal on the left side`` () = 
+        " \"String Literal\" ?? \"Default\" "
+        |> parseTemplateValue 
+        |> should equal (TemplateValue.NullCoalesce(TemplateValue.Literal("String Literal"), TemplateValue.Literal("Default")))
+
+    [<Test>]
+    let ``Parses null coalesce operator with number literal on the left side`` () = 
+        " 0 ?? \"Default\" "
+        |> parseTemplateValue 
+        |> should equal (TemplateValue.NullCoalesce(TemplateValue.Literal(0), TemplateValue.Literal("Default")))
+
+    [<Test>]
+    let ``Parses null coalesce operator with simple value on the left side`` () = 
+        " var ?? \"Default\" "
+        |> parseTemplateValue 
+        |> should equal (TemplateValue.NullCoalesce(TemplateValue.SimpleValue("var"), TemplateValue.Literal("Default")))
+
+    [<Test>]
+    let ``Parses null coalesce operator with a function on the left side`` () = 
+        " fn() ?? \"Default\" "
+        |> parseTemplateValue 
+        |> should equal (TemplateValue.NullCoalesce(TemplateValue.Function("fn", []), TemplateValue.Literal("Default")))
+
+    [<Test>]
+    let ``Parses null coalesce operator with simple value on the right side`` () = 
+        " \"Default\" ?? var"
+        |> parseTemplateValue 
+        |> should equal (TemplateValue.NullCoalesce(TemplateValue.Literal("Default"), TemplateValue.SimpleValue("var")))
+
+    [<Test>]
+    let ``Parses null coalesce operator with a function on the right side`` () = 
+        " \"Default\" ?? fn() "
+        |> parseTemplateValue 
+        |> should equal (TemplateValue.NullCoalesce(TemplateValue.Literal("Default"), TemplateValue.Function("fn", [])))
+
+    [<Test>]
+    let ``Parses null coalesce operator as function parameter`` () = 
+        " fn(var ?? \"Default\") "
+        |> parseTemplateValue 
+        |> should equal (TemplateValue.Function("fn", [TemplateValue.NullCoalesce(TemplateValue.SimpleValue("var"), TemplateValue.Literal("Default"))]))
+
 
 [<Test>]
 let ``Parses simple value`` () = 


### PR DESCRIPTION
I wanted to be able to provide default values in case a variable isn't defined.

I chose the null coalescing operator from c# `??` for the job but I'm open to other suggestions.

The way it works is quite simple, if the left side is defined it uses that, if not, it uses the right side:
`{{{value ?? "default value"}}}`

Note that if the left side is a function and defined and returns a null-ish result, then that will still be used.
```fsharp
let template = {{{fn() ?? "default value"}}}
init 
|> add "fn" (fun () -> null)
|> fromText template
```
Would evaluate to nothing.

This is behaviour I'm unsure of - should `??` evaluate the right side if the result of the left is `null`?
What about an empty string?