### PR TITLE
Add support for conditionally rendered for-cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,12 @@ let compiledHtml =
 // compiledHtml is "<li>A is 0, 1, 3</li><li>B is 1, 2, 3</li><li>C is 2, 3, 3</li>"
 ```
 
+Sometimes you don't want to render all items of a list.
+You can either prefilter the items `fs-for"i in filter(items)"` or alternatively you can combine `fs-for` with `fs-if`
+```fsharp
+let html = """<li fs-if"filter(i)" fs-for="i in items">{{{i}}} is {{{$index}}}, {{{$iteration}}}, {{{$length}}}</li>"""
+```
+
 Since version 1.2.0 there is support for tuples destructuring:
 
 ```fsharp

--- a/src/Fue/Core.fs
+++ b/src/Fue/Core.fs
@@ -9,6 +9,7 @@ type TemplateValue =
 
 type TemplateNode =
     | ForCycle of item:string * source:TemplateValue
+    | ConditionalForCycle of item: string * source:TemplateValue * condition: TemplateValue
     | IfCondition of source:TemplateValue
     | ElseCondition
     | DiscriminatedUnion of union:TemplateValue * case:string * extract:string list

--- a/tests/Fue.Tests/Compiler.fs
+++ b/tests/Fue.Tests/Compiler.fs
@@ -238,6 +238,14 @@ let ``Compiles with Some directly`` () =
     |> should equal "<div>Ano</div>"
 
 [<Test>]
+let ``Compiles conditional for directives`` () = 
+    init 
+    |> add "y" ["";"a";"b";]
+    |> add "notEmpty" (String.IsNullOrWhiteSpace >> not)
+    |> fromText """<ul><li fs-if="notEmpty(x)" fs-for="x in y">{{{x}}}</li></ul>"""
+    |> should equal "<ul><li>a</li><li>b</li></ul>"
+
+[<Test>]
 let ``Compiles with None directly`` () = 
     init 
     |> add "value" { Name = "AAA"; Surname = None}

--- a/tests/Fue.Tests/Parser.fs
+++ b/tests/Fue.Tests/Parser.fs
@@ -445,21 +445,19 @@ let ``Parses simple value with white spaces`` () =
 let ``Parses for-cycle value`` () = 
     "x in y" 
     |> parseForCycleAttribute 
-    |> should equal (TemplateNode.ForCycle("x", TemplateValue.SimpleValue("y")) |> Some)
+    |> should equal (("x", "y") |> Some)
 
 [<Test>]
 let ``Parses for-cycle value with function`` () = 
     "x in y(z)" 
     |> parseForCycleAttribute 
-    |> should equal (TemplateNode.ForCycle("x", TemplateValue.Function("y", [TemplateValue.SimpleValue("z")])) |> Some)
+    |> should equal (("x", "y(z)") |> Some)
 
 [<Test>]
 let ``Parses for-cycle value with piped function`` () = 
     "x in y |> z 'lit'" 
     |> parseForCycleAttribute 
-    |> should equal (
-        TemplateNode.ForCycle("x", 
-            TemplateValue.Function("z", [TemplateValue.Literal("lit"); TemplateValue.SimpleValue("y")])) |> Some)
+    |> should equal (("x", "y |> z 'lit'") |> Some)
 
 [<Test>]
 let ``Does not parse illegal for-cycle value`` () = 


### PR DESCRIPTION
This one is ready

Sometimes I don't want to render all entries of a list (for example if there's an empty string).
Having a singular function that checks for `String.IsNullOrEmpty` has more chance of being reused than a function that filters a list.

This PR enables you to combine `fs-if` with `fs-for`
```html
<li fs-if"filter(i)" fs-for="i in items">{{{i}}} is {{{$index}}}, {{{$iteration}}}, {{{$length}}}</li>
```

I think this fits nicely with the current semantic of `fs-if` because it doesn't behave differently.

What might be surprising to some is that in this case `fs-if` gets evaluated for every `i`, even if it does not reference `i`.
Even so, the outcome is the same in either case: if the condition is true, everything will get rendered. If it's false nothing will get rendered.